### PR TITLE
Reflection Signature Fix

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -314,6 +314,9 @@ CONSTRUCTOR;
             }
             // paramName
             $signature .= '$' . $parameter->getName();
+
+            $variadic = PHP_VERSION_ID >= 50600 ? $parameter->isVariadic() : false;
+
             // defaultValue
             if ($parameter->isDefaultValueAvailable()) {
                 $signature .= ' = ';
@@ -322,6 +325,12 @@ CONSTRUCTOR;
                 } else {
                     $signature .= var_export($parameter->getDefaultValue(), true);
                 }
+            } else if ($parameter->isOptional() && !$variadic) {
+                $signature .= ' = null';
+            }
+
+            if ($variadic) {
+                $signature = '...' . $signature;
             }
 
             $signatures[] = $signature;

--- a/tests/units/RedisMockFactory.php
+++ b/tests/units/RedisMockFactory.php
@@ -261,6 +261,38 @@ class RedisMockFactory extends test
         ;
 
     }
+
+    /**
+     * Test that the php-redis extension can be mocked.
+     */
+    public function testRedisExt() {
+        if (!class_exists(\Redis::class)) {
+            $this->skip('Redis ext is required');
+        }
+
+        $factory = new Factory();
+        $mock = $factory->getAdapter(\Redis::class, true);
+
+        $this->assert
+            ->object($mock)
+            ->isInstanceOf('Redis')
+        ;
+
+        $this->assert
+            ->string($mock->set('test', 'aaa'))
+            ->isEqualTo('OK')
+            ->string($mock->get('test'))
+            ->isEqualTo('aaa')
+        ;
+
+        $this->assert
+            ->exception(function() use ($mock) {
+                $mock->append('foo', 'bar');
+            })
+            ->isInstanceOf('\M6Web\Component\RedisMock\UnsupportedException')
+            ->hasMessage('Redis command append is not supported by RedisMock.')
+        ;
+    }
 }
 
 class RedisWithMethods


### PR DESCRIPTION
- Updated the method code generation to support nullable and variadic params. This resolves issue #73.
- Added a test case for validating that the php-redis implementation can be mocked.