### PR TITLE
scan() method not working with pattern containing slashes

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1250,7 +1250,8 @@ class RedisMock
         // Matched values.
         $values = [];
         // Pattern, for find matched values.
-        $pattern =  str_replace('*', '.*', sprintf('/^%s$/', $match));
+        $escapedMatch = str_replace('/', '\/', $match);
+        $pattern =  str_replace('*', '.*', sprintf('/^%s$/', $escapedMatch));
 
         for($i = $cursor; $i <= $maximumValue; $i++)
         {

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1898,6 +1898,8 @@ class RedisMock extends atoum
         $redisMock->lpush('key10', 'value10');
         $redisMock->lpush('key11', 'value11');
         $redisMock->lpush('key12', 'value12');
+        $redisMock->lpush('slash-key/with/slashes/1', 'slash-value-1');
+        $redisMock->lpush('slash-key/with/slashes/2', 'slash-value-2');
 
         // It must return two values, start cursor after the first value of the list.
         $this->assert
@@ -1917,5 +1919,9 @@ class RedisMock extends atoum
             ->array($redisMock->scan(10, ['MATCH' => '*our*']))
             ->isEqualTo([0, []]);
 
+        // It must return all the values with match with the regex with '/'
+        $this->assert
+            ->array($redisMock->scan(0, ['MATCH' => 'slash-key/*/*', 'COUNT' => 100]))
+            ->isEqualTo([0, [0 => 'slash-key/with/slashes/1', 1 => 'slash-key/with/slashes/2']]);
     }
 }


### PR DESCRIPTION
The `scan()` method does not work when a slash character `/` is used in a key or in the match pattern.

The reason behind this is because the character `/` is also used in the regex as a the regex delimiter, so every original `/` must be escaped in order to work properly.