### PR TITLE
Adds zunionstore() and zcount() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Redis command                                    | Description
 **ZADD** *key* *score* *member*                  | Adds one member to a sorted set, or update its score if it already exists
 **ZINCRBY** *key* *increment* *member*           | Increments the score of *member* in the sorted set stored at *key* by *increment*
 **ZCARD** *key*                                  | Returns the sorted set cardinality (number of elements) of the sorted set stored at *key*
+**ZCOUNT** **key** **min** **max**               | Returns the number of elements in the stored set at *key* with a score between *min* and *max*.      
 **ZRANGE** *key* *start* *stop* *[withscores]*   | Returns the specified range of members in a sorted set
 **ZRANGEBYSCORE** *key* *min* *max* *options*    | Returns a range of members in a sorted set, by score
 **ZRANK** *key* *member*                         | Returns the rank of *member* in the sorted set stored at *key*, with the scores ordered from low to high

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Redis command                                    | Description
 **ZREVRANGE** *key* *start* *stop* *[withscores]*| Returns the specified range of members in a sorted set, with scores ordered from high to low
 **ZREVRANGEBYSCORE** *key* *min* *max* *options* | Returns a range of members in a sorted set, by score, with scores ordered from high to low
 **ZSCORE** *key* *member*                        | Returns the score of *member* in the sorted set at *key*
+**ZUNIONSTORE** *dest* *numkeys* *key* ... *[weights ...]* *[aggregate SUM/MIN/MAX]*  | Computes the union of the stored sets given by the specified keys, store the result in the destination key, and returns the number of elements of the new sorted set.
 
 
 It mocks **MULTI**, **DISCARD** and **EXEC** commands but without any transaction behaviors, they just make the interface fluent and return each command results.

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1120,6 +1120,43 @@ class RedisMock
         return $this->returnPipedInfo(1);
     }
 
+    public function zunionstore($destination, array $keys, array $options = array())
+    {
+        $weights = isset($options['WEIGHTS']) ? $options['WEIGHTS'] : array_fill(0, count($keys), 1);
+        $aggregate = isset($options['AGGREGATE']) ? $options['AGGREGATE'] : 'SUM';
+
+        if (count($weights) !== count($keys)) {
+            throw new \RuntimeException('there must be one weight per key');
+        }
+
+        if ($aggregate !== 'SUM' && $aggregate !== 'MIN' && $aggregate !== 'MAX') {
+            throw new \RuntimeException('unknown aggregate function');
+        }
+
+        $this->del($destination);
+        foreach ($keys as $index => $key) {
+            foreach ($this->zrangebyscore($key, '-inf', '+inf', array('withscores' => true)) as $member => $score) {
+                $weight = $weights[$index];
+                $weightedScore = $score * $weight;
+
+                $currentScore = $this->zscore($destination, $member);
+                if ($currentScore === null) {
+                    $this->zadd($destination, $weightedScore, $member);
+                } else if ($aggregate === 'SUM') {
+                    $this->zincrby($destination, $weightedScore, $member);
+                } else if ($aggregate === 'MIN') {
+                    $finalScore = min($currentScore, $weightedScore);
+                    $this->zadd($destination, $finalScore, $member);
+                } else if ($aggregate === 'MAX') {
+                    $finalScore = max($currentScore, $weightedScore);
+                    $this->zadd($destination, $finalScore, $member);
+                }
+            }
+        }
+
+        return $this->zcount($destination, '-inf', '+inf');
+    }
+
     // Server
 
     public function dbsize()

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1029,6 +1029,16 @@ class RedisMock
         return $this->returnPipedInfo(count(self::$dataValues[$this->storage][$key]));
     }
 
+    public function zcount($key, $min, $max)
+    {
+        $result = $this->zrangebyscore($key, $min, $max);
+        if (!is_array($result)) {
+            return $result;
+        }
+
+        return count($result);
+    }
+
     public function zincrby($key, $increment, $member)
     {
         if (!isset(self::$dataValues[$this->storage][$key][$member]) || $this->deleteOnTtlExpired($key)) {

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -748,6 +748,26 @@ class RedisMock extends atoum
                 ->isEqualTo(0);
     }
 
+    public function testZCount()
+    {
+        $redisMock = new Redis();
+        $redisMock->zadd('myzset', 1, 'one');
+        $redisMock->zadd('myzset', 2, 'two');
+        $redisMock->zadd('myzset', 3, 'three');
+
+        $this->assert
+            ->integer($redisMock->zcount('myzset', '-inf', '+inf'))
+            ->isEqualTo(3);
+
+        $this->assert
+            ->integer($redisMock->zcount('myzset', '(1', 3))
+            ->isEqualTo(2);
+
+        $this->assert
+            ->integer($redisMock->zcount('unexisting set', 0, 10))
+            ->isEqualTo(0);
+    }
+
     public function testZAddWithArray()
     {
         $redisMock = new Redis();


### PR DESCRIPTION
Adding `zunionstore()` and `zcount()` methods.

`predis` documentation states that `zcount` returns a string, but that's not the case