### PR TITLE
Added RedisMock::bitcount, RedisMock::getbit, RedisMock::setbit commands

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1326,11 +1326,7 @@ class RedisMock
      */
     public function bitcount($key)
     {
-        if (!isset(self::$dataValues[$this->storage][$key])) {
-            self::$dataValues[$this->storage][$key] = [];
-        }
-
-        return count(self::$dataValues[$this->storage][$key]);
+        return count(self::$dataValues[$this->storage][$key] ?? []);
     }
 
     /**

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -1316,4 +1316,55 @@ class RedisMock
     {
         return;
     }
+
+    /**
+     * Mock the `bitcount` command
+     * @see https://redis.io/commands/bitcount
+     *
+     * @param  string $key
+     * @return int
+     */
+    public function bitcount($key)
+    {
+        if (!isset(self::$dataValues[$this->storage][$key])) {
+            self::$dataValues[$this->storage][$key] = [];
+        }
+
+        return count(self::$dataValues[$this->storage][$key]);
+    }
+
+    /**
+     * Mock the `setbit` command
+     * @see https://redis.io/commands/setbit
+     *
+     * @param string $key
+     * @param int $offset
+     * @param int $value
+     * @return int original value before the update
+     */
+    public function setbit($key, $offset, $value)
+    {
+        if (!isset(self::$dataValues[$this->storage][$key])) {
+            self::$dataValues[$this->storage][$key] = [];
+        }
+
+        $originalValue = self::$dataValues[$this->storage][$key][$offset] ?? 0;
+
+        self::$dataValues[$this->storage][$key][$offset] = $value;
+
+        return $originalValue;
+    }
+
+    /**
+     * Mock the `getbit` command
+     * @see https://redis.io/commands/getbit
+     *
+     * @param string $key
+     * @param int $offset
+     * @return int
+     */
+    public function getbit($key, $offset)
+    {
+        return self::$dataValues[$this->storage][$key][$offset] ?? 0;
+    }
 }

--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -216,7 +216,7 @@ METHODEXCEPTION;
 
     public function __construct()
     {
-
+        
     }
 CONSTRUCTOR;
 

--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -14,9 +14,6 @@ namespace M6Web\Component\RedisMock;
 class RedisMockFactory
 {
     protected $redisCommands = array(
-        'bitcount',
-        'setbit',
-        'getbit',
         'append',
         'auth',
         'bgrewriteaof',

--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -4,16 +4,19 @@ namespace M6Web\Component\RedisMock;
 
 /**
  * Adapter allowing to setup a Redis Mock inheriting of an arbitrary class
- * 
+ *
  * WARNING ! RedisMock doesn't implement all Redis features and commands.
  * The mock can have undesired behavior if your parent class uses unsupported features.
- * 
+ *
  * @author Adrien Samson <asamson.externe@m6.fr>
  * @author Florent Dubost <fdubost.externe@m6.fr>
  */
 class RedisMockFactory
 {
     protected $redisCommands = array(
+        'bitcount',
+        'setbit',
+        'getbit',
         'append',
         'auth',
         'bgrewriteaof',
@@ -213,7 +216,7 @@ METHODEXCEPTION;
 
     public function __construct()
     {
-        
+
     }
 CONSTRUCTOR;
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1919,7 +1919,7 @@ class RedisMock extends atoum
 
     }
 
-    public function testBitCountCommand()
+    public function testBitcountCommand()
     {
         $redisMock = new Redis();
         $redisMock->setbit('myKey', 0, 0);

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1930,7 +1930,7 @@ class RedisMock extends atoum
         $this->assert->variable($redisMock->bitcount('otherKey'))->isEqualTo(0);
     }
 
-    public function testBitGetCommand()
+    public function testGetbitCommand()
     {
         $redisMock = new Redis();
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1940,7 +1940,7 @@ class RedisMock extends atoum
         $this->assert->variable($redisMock->getbit('myKey', 0))->isEqualTo(1);
     }
 
-    public function testBitSetCommand()
+    public function testSetbitCommand()
     {
         $redisMock = new Redis();
 

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1918,4 +1918,39 @@ class RedisMock extends atoum
             ->isEqualTo([0, []]);
 
     }
+
+    public function testBitCountCommand()
+    {
+        $redisMock = new Redis();
+        $redisMock->setbit('myKey', 0, 0);
+        $redisMock->setbit('myKey', 1, 1);
+        $redisMock->setbit('myKey', 2, 1);
+
+
+        // It must return two values, start cursor after the first value of the list.
+        $this->assert->variable($redisMock->bitcount('myKey'))->isEqualTo(3);
+        $this->assert->variable($redisMock->bitcount('otherKey'))->isEqualTo(0);
+    }
+
+    public function testBitGetCommand()
+    {
+        $redisMock = new Redis();
+
+        $this->assert->variable($redisMock->getbit('myKey', 0))->isEqualTo(0);
+
+        $redisMock->setbit('myKey', 0, 1);
+        $this->assert->variable($redisMock->getbit('myKey', 0))->isEqualTo(1);
+    }
+
+    public function testBitSetCommand()
+    {
+        $redisMock = new Redis();
+
+        $this->assert->variable($redisMock->getbit('myKey', 0))->isEqualTo(0);
+
+        $returnValue = $redisMock->setbit('myKey', 0, 1);
+        $this->assert->variable($returnValue)->isEqualTo(0);
+        $returnValue = $redisMock->setbit('myKey', 0, 0);
+        $this->assert->variable($returnValue)->isEqualTo(1);
+    }
 }

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1926,8 +1926,6 @@ class RedisMock extends atoum
         $redisMock->setbit('myKey', 1, 1);
         $redisMock->setbit('myKey', 2, 1);
 
-
-        // It must return two values, start cursor after the first value of the list.
         $this->assert->variable($redisMock->bitcount('myKey'))->isEqualTo(3);
         $this->assert->variable($redisMock->bitcount('otherKey'))->isEqualTo(0);
     }


### PR DESCRIPTION
This branch is extending the functionality of RedisMock to support the:

- `bitcount`
- `getbit`
- `setbit`

Redis commands