### PR TITLE
sscan implementation based on existing scan method

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Redis command                                    | Description
 **RPUSH** *key* *value*                          | Pushs values at the tail of a list
 **RPOP** *key*                                   | Pops values at the tail of a list
 **SCAN**                                         | Iterates the set of keys in the currently selected Redis database.
+**SSCAN**                                        | Iterates elements of Sets types.
 **SET** *key* *value*                            | Sets the string value of a key
 **SETEX** *key* *seconds* *value*                | Sets the value and expiration of a key
 **SETNX** *key* *value*                          | Sets key to hold value if key does not exist

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -464,6 +464,54 @@ class RedisMock
         return $this->returnPipedInfo(1);
     }
 
+
+    /**
+     * Mock the `sscan` command
+     * @see https://redis.io/commands/sscan
+     * @param string $key
+     * @param int $cursor
+     * @param array $options contain options of the command, with values (ex ['MATCH' => 'st*', 'COUNT' => 42] )
+     * @return $this|array|mixed
+     */
+    public function sscan($key, $cursor = 0, array $options = [])
+    {
+        $match = isset($options['MATCH']) ? $options['MATCH'] : '*';
+        $count = isset($options['COUNT']) ? $options['COUNT'] : 10;
+        $maximumValue = $cursor + $count -1;
+
+        if (!isset(self::$dataValues[$this->storage][$key]) || $this->deleteOnTtlExpired($key)) {
+            return $this->returnPipedInfo([0, []]);
+        }
+
+        // List of all keys in the storage (already ordered by index).
+        $set = self::$dataValues[$this->storage][$key];
+        $maximumListElement = count($set);
+
+        // Next cursor position
+        $nextCursorPosition = 0;
+        // Matched values.
+        $values = [];
+        // Pattern, for find matched values.
+        $pattern =  str_replace('*', '.*', sprintf('/^%s$/', $match));
+
+        for($i = $cursor; $i <= $maximumValue; $i++)
+        {
+            if (isset($set[$i])){
+                $nextCursorPosition = $i >= $maximumListElement ? 0 : $i + 1;
+
+                if ('*' === $match || 1 === preg_match($pattern, $set[$i])){
+                    $values[] = $set[$i];
+                }
+
+            } else {
+                // Out of the arrays values, return first element
+                $nextCursorPosition = 0;
+            }
+        }
+
+        return $this->returnPipedInfo([$nextCursorPosition, $values]);
+    }
+
     // Lists
 
     public function llen($key)

--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -492,7 +492,7 @@ class RedisMock
         // Matched values.
         $values = [];
         // Pattern, for find matched values.
-        $pattern =  str_replace('*', '.*', sprintf('/^%s$/', $match));
+        $pattern = sprintf('/^%s$/', str_replace(['*', '/'], ['.*', '\/'], $match));
 
         for($i = $cursor; $i <= $maximumValue; $i++)
         {

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1919,6 +1919,33 @@ class RedisMock extends atoum
 
     }
 
+    public function testSscanCommand()
+    {
+        $redisMock = new Redis();
+        $redisMock->sadd('myKey', 'a1');
+        $redisMock->sadd('myKey', ['b1', 'b2', 'b3', 'b4', 'b5', 'b6']);
+        $redisMock->sadd('myKey', ['c1', 'c2', 'c3']);
+
+        // It must return two values, start cursor after the first value of the list.
+        $this->assert
+            ->array($redisMock->sscan('myKey', 1, ['COUNT' => 2]))
+            ->isEqualTo([3, [0 => 'b1', 1 => 'b2']]);
+
+
+        // It must return all the values with match with the regex 'our' (2 keys).
+        // And the cursor is defined after the default count (10) => the match has not terminate all the list.
+        $this->assert
+            ->array($redisMock->sscan('myKey', 0, ['MATCH' => 'c*']))
+            ->isEqualTo([10, [0 => 'c1', 1 => 'c2', 2 => 'c3']]);
+
+        // Execute the match at the end of this list, the match not return an element (no one element match with the regex),
+        // And the list is terminate, return the cursor to the start (0)
+        $this->assert
+            ->array($redisMock->sscan('myKey', 11, ['MATCH' => 'c*']))
+            ->isEqualTo([0, []]);
+
+    }
+
     public function testBitcountCommand()
     {
         $redisMock = new Redis();

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1925,17 +1925,21 @@ class RedisMock extends atoum
         $redisMock->sadd('myKey', 'a1');
         $redisMock->sadd('myKey', ['b1', 'b2', 'b3', 'b4', 'b5', 'b6']);
         $redisMock->sadd('myKey', ['c1', 'c2', 'c3']);
+        $redisMock->sadd('a/b', 'c/d');
 
         // It must return no values, as the key is unknown.
         $this->assert
             ->array($redisMock->sscan('unknown', 1, ['COUNT' => 2]))
             ->isEqualTo([0, []]);
 
+        $this->assert
+            ->array($redisMock->sscan('a/b', 0, ['MATCH' => 'c/*']))
+            ->isEqualTo([0, [0 => 'c/d']]);
+
         // It must return two values, start cursor after the first value of the list.
         $this->assert
             ->array($redisMock->sscan('myKey', 1, ['COUNT' => 2]))
             ->isEqualTo([3, [0 => 'b1', 1 => 'b2']]);
-
 
         // It must return all the values with match with the regex 'our' (2 keys).
         // And the cursor is defined after the default count (10) => the match has not terminate all the list.

--- a/tests/units/RedisMock.php
+++ b/tests/units/RedisMock.php
@@ -1926,6 +1926,11 @@ class RedisMock extends atoum
         $redisMock->sadd('myKey', ['b1', 'b2', 'b3', 'b4', 'b5', 'b6']);
         $redisMock->sadd('myKey', ['c1', 'c2', 'c3']);
 
+        // It must return no values, as the key is unknown.
+        $this->assert
+            ->array($redisMock->sscan('unknown', 1, ['COUNT' => 2]))
+            ->isEqualTo([0, []]);
+
         // It must return two values, start cursor after the first value of the list.
         $this->assert
             ->array($redisMock->sscan('myKey', 1, ['COUNT' => 2]))
@@ -1944,6 +1949,13 @@ class RedisMock extends atoum
             ->array($redisMock->sscan('myKey', 11, ['MATCH' => 'c*']))
             ->isEqualTo([0, []]);
 
+        $redisMock->expire('myKey', 1);
+        sleep(2);
+
+        // It must return no values, as the key is expired.
+        $this->assert
+            ->array($redisMock->sscan('myKey', 1, ['COUNT' => 2]))
+            ->isEqualTo([0, []]);
     }
 
     public function testBitcountCommand()


### PR DESCRIPTION
Here is another approach to implement sscan for the mock library. Fixes #98 and supersedes #100.