### PR TITLE
Add variadic param name

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -319,7 +319,12 @@ CONSTRUCTOR;
                 $signature .= '&';
             }
             // paramName
-            $signature .= '$' . $parameter->getName();
+            $paramName = '$' . $parameter->getName();
+            // variadic
+            if ($parameter->isVariadic()) {
+                $paramName = '...' . $paramName;
+            }
+            $signature .= $paramName;
             // defaultValue
             if ($parameter->isDefaultValueAvailable()) {
                 $signature .= ' = ';


### PR DESCRIPTION
In predis tag [v2.1.2](https://github.com/predis/predis/releases/tag/v2.1.2), the method signature of pipeline changed to contain a variadic argument, thus the mock generates an incompatible method signature. This just adds the `...` if the argument is variadic.